### PR TITLE
Fix for btrfs sub list returning all subvolumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Btrfs snapshot backup utility
 
 ```
 btrfs-sxbackup.py --help
-btrfs-sxbackup v0.3.0 by masc
+btrfs-sxbackup v0.3.1 by masc
 usage: btrfs-sxbackup.py [-h] [-sm SOURCE_MAX_SNAPSHOTS]
                          [-dm DESTINATION_MAX_SNAPSHOTS]
                          [-ss SOURCE_CONTAINER_SUBVOLUME] [-c] [-li LOG_IDENT]

--- a/btrfs-sxbackup.py
+++ b/btrfs-sxbackup.py
@@ -125,18 +125,35 @@ class SxBackup:
         def retrieve_snapshot_names(self):
             ''' Determine snapshot names. Snapshot names are sorted in reverse order (newest first).
             stored internally (self.snapshot_names) and also returned. '''
-
-            self.log_info('Retrieving snapshot names')
+            subvolpath = os.path.abspath(self.container_subvolume).rstrip(os.path.sep)
+            self.log_info('Retrieving snapshot names for %s' % subvolpath)
             output = subprocess.check_output(self.create_subprocess_args('btrfs sub list -o %s' % (self.container_subvolume)))
             # output is delivered as a byte sequence, decode to unicode string and split lines
             lines = output.decode().splitlines()
+
             # extract snapshot names from btrfs sub list lines
-            def strip_name(l):
+            # this also takes the full path of the subvolume to validate that the snapshots returned by
+            # btrfs subvol list are really within the expected path.
+            # this is possibly a bug in btrfs v3.17 subvol list, kernel 3.18 or due to a bad written btrfs manual page.
+            def strip_name(l, subvol_path):
                 i = l.rfind(os.path.sep)
-                return l[i+1:] if i >= 0 else l
-            lines = map(lambda x: strip_name(x), lines)
+                if i >= 0:
+                    folder = l[l.rfind(' ', 0, i):i].strip()
+                    if subvol_path.endswith(folder):
+                        return l[i+1:]
+                    else:
+                        return False
+                else:
+                    return l
+
+            self.snapshot_names = []
+            # container_subvolume can be both absolute or relative path depending on user input, so make it absolute
+            for line in lines:
+                result = strip_name(line, subvolpath)
+                if result:
+                    self.snapshot_names.append(result)
             # sort and return
-            self.snapshot_names = sorted(lines, reverse=True)
+            self.snapshot_names = sorted(self.snapshot_names, reverse=True)
             return self.snapshot_names
 
         def cleanup_snapshots(self):

--- a/btrfs-sxbackup.py
+++ b/btrfs-sxbackup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __author__ = 'Marco Schindler, Bernd Michael Helm'
 __email__ = 'masc@disappear.de'
 __maintainer__ = 'masc@disappear.de'


### PR DESCRIPTION
i have noticed that the cleanup method tries to delete subvolumes that are not within the current container_subvolume on the destination.

i.e. i have a btrfs volume in /home/backup that contains directories mg, ag and bd which are used as destination paths for independend backup jobs.

and here is my problem:
    root@backup:/home/backup/mg# btrfs sub list -o /home/backup/mg/
    ID 380 gen 482 top level 5 path ag/sx-20141210-111236-utc
    ID 645 gen 738 top level 5 path ag/sx-20141211-021209-utc
    ID 648 gen 743 top level 5 path bd/sx-20141211-024803-utc
    ID 775 gen 867 top level 5 path ag/sx-20141212-021210-utc
    ID 777 gen 874 top level 5 path bd/sx-20141212-024806-utc
    ID 781 gen 885 top level 5 path mg/sx-20141212-032206-utc
    ID 837 gen 997 top level 5 path ag/sx-20141213-021208-utc

the command actuelly does not only return snapshots from within mg directory, instead it displays ALL snapshots from /home/backup. This is causing sxbackup to try to delete non-existing snapshots from /home/backup/mg which fails.

This commit works around this by determining the full path to destination directory and verifying that it matches what btrfs sub list returns.

Im not sure if it is a bug in btrfs sub list or not, so i would ask you to confirm if you can reproduce the problem with btrfs sub list -o.

Also bumped the version number to 0.3.1