### PR TITLE
Allow modification of the source volume root's mtime to be disabled.

### DIFF
--- a/btrfs_sxbackup/__main__.py
+++ b/btrfs_sxbackup/__main__.py
@@ -107,6 +107,10 @@ def main():
                             ' default email-recipient setting in /etc/btrfs-sxbackup.conf')
     p_run.add_argument('-li', '--log-ident', dest='log_ident', type=str, default=None,
                        help='log ident used for syslog logging, defaults to script name')
+    p_run_touch = p_run.add_mutually_exclusive_group(required=False)
+    p_run_touch.add_argument('--touch-source', dest='touch_source', action='store_true', help='touch source volume root before creating the snapshot to update its mtime. This is the default since version 0.5.9.')
+    p_run_touch.add_argument('--no-touch-source', dest='touch_source', action='store_false', help='do not touch source volume root.')
+    p_run.set_defaults(touch_source=True)
 
     # Info command cmdline params
     p_info = subparsers.add_parser(_CMD_INFO, help='backup job info')
@@ -213,7 +217,7 @@ def main():
             for subvolume in args.subvolumes:
                 try:
                     job = Job.load(urllib.parse.urlsplit(subvolume))
-                    job.run()
+                    job.run(args.touch_source)
                 except Exception as e:
                     handle_exception(e)
                     exitcode = 1
@@ -291,4 +295,3 @@ def main():
     exit(exitcode)
 
 main()
-


### PR DESCRIPTION
First, I'd like to give you a short thank you for this project! It has been an important part of my backup strategy for the last 2 years. I have still been using version 0.5.5 until recently, when I started to encounter some issues and was forced to update. The update to version 0.6.10 resolved those issues but cause a new one for me: 

ERROR touch: setting times of ‘/home/’: Permission denied

On the remote end, I am running btrfs-sxbackup as an user with limited privileges. While I could extend those privileges and allow setting the mtime I also feel that the script should not modify the backup source. So, I took the liberty of adding a new command line switch, allowing me to disable this "new" mtime-feature at need.

I would appreciate it if you might consider merging these changes back into the project.