### PR TITLE
Do not use btrfs send and receive when source and destination are on the same btrfs filesystem

### DIFF
--- a/btrfs_sxbackup/__init__.py
+++ b/btrfs_sxbackup/__init__.py
@@ -5,7 +5,7 @@
 # Software Foundation; either version 2 of the License, or (at your option)
 # any later version.
 
-__version__ = '0.6.12'
+__version__ = '0.6.12.identical_filesystem'
 __author__ = 'Marco Schindler'
 __email__ = 'masc@disappear.de'
 __maintainer__ = 'masc@disappear.de'

--- a/btrfs_sxbackup/cli.py
+++ b/btrfs_sxbackup/cli.py
@@ -83,7 +83,6 @@ p_init.add_argument('destination_subvolume', type=str, metavar='destination-subv
 p_init.add_argument(*source_retention_args, **source_retention_kwargs)
 p_init.add_argument(*destination_retention_args, **destination_retention_kwargs)
 p_init.add_argument(*compress_args, **compress_kwargs)
-p_init.add_argument('--identical_filesystem', action='store_true', help='This avoids btrfs send/receive when the source and destination subvolumes are on the same btrfs filesystem')
 
 p_destroy = subparsers.add_parser(_CMD_DESTROY, help='destroy backup job by removing configuration files from source'
                                                      ' and destination. backup snapshots will be kept on both sides'
@@ -228,8 +227,7 @@ def main():
                            dest_url=urllib.parse.urlsplit(args.destination_subvolume) if args.destination_subvolume
                            else None,
                            dest_retention=destination_retention,
-                           compress=args.compress,
-                           identical_filesystem=args.identical_filesystem)
+                           compress=args.compress)
 
         elif args.command == _CMD_UPDATE:
             source_retention = RetentionExpression(args.source_retention) if args.source_retention else None

--- a/btrfs_sxbackup/cli.py
+++ b/btrfs_sxbackup/cli.py
@@ -83,6 +83,7 @@ p_init.add_argument('destination_subvolume', type=str, metavar='destination-subv
 p_init.add_argument(*source_retention_args, **source_retention_kwargs)
 p_init.add_argument(*destination_retention_args, **destination_retention_kwargs)
 p_init.add_argument(*compress_args, **compress_kwargs)
+p_init.add_argument('--identical_filesystem', action='store_true', help='This avoids btrfs send/receive when the source and destination subvolumes are on the same btrfs filesystem')
 
 p_destroy = subparsers.add_parser(_CMD_DESTROY, help='destroy backup job by removing configuration files from source'
                                                      ' and destination. backup snapshots will be kept on both sides'
@@ -227,7 +228,8 @@ def main():
                            dest_url=urllib.parse.urlsplit(args.destination_subvolume) if args.destination_subvolume
                            else None,
                            dest_retention=destination_retention,
-                           compress=args.compress)
+                           compress=args.compress,
+                           identical_filesystem=args.identical_filesystem)
 
         elif args.command == _CMD_UPDATE:
             source_retention = RetentionExpression(args.source_retention) if args.source_retention else None

--- a/btrfs_sxbackup/core.py
+++ b/btrfs_sxbackup/core.py
@@ -182,6 +182,8 @@ class Location:
         :param path: Base path
         :return: Contextual path
         """
+        if path is None:
+            path = ''
         return os.path.abspath(os.path.join(self.url.path, path))
 
     def get_kernel_version(self):

--- a/btrfs_sxbackup/core.py
+++ b/btrfs_sxbackup/core.py
@@ -175,20 +175,14 @@ class Location:
         """
         return shell.build_subprocess_args(cmd, self.url)
 
-    def build_path(self, path: str) -> str:
+    def build_path(self, path: str = '') -> str:
         """
         Creates a path in the context of this location.
         Relative paths will be joined with the location's url path
         :param path: Base path
         :return: Contextual path
         """
-        if not path:
-            return self.url.path
-
-        if path.startswith(os.path.sep):
-            return path
-        else:
-            return os.path.join(self.url.path, path)
+        return os.path.abspath(os.path.join(self.url.path, path))
 
     def get_kernel_version(self):
         return self.exec_check_output('uname -srvo').decode().strip()


### PR DESCRIPTION
This allows the source and destination to be on the same btrfs filesystem.
It keeps the operation identical as possible regular btrfs-sxbackup
The major difference is in Location.transfer_btrfs_snapshot().
transfer_btrfs_snapshot does not use btrfs send/receive whe identical_filesystem is enabled.
It simply takes a new snapshot of the source snapshot.

identical_filesystem is enabled as follows:
btrfs-sxbackup --identical_filesystem
