### PR TITLE
Raised ssh keep-alive timeout in case source system is really slow

### DIFF
--- a/btrfs_sxbackup/shell.py
+++ b/btrfs_sxbackup/shell.py
@@ -25,7 +25,7 @@ def build_subprocess_args(cmd, url=None):
     # wrap into bash or ssh command respectively
     # depending if command is executed locally (host==None) or remotely
     url_string = None
-    ssh_args = ['ssh', '-o', 'ServerAliveInterval=5', '-o', 'ServerAliveCountMax=3']
+    ssh_args = ['ssh', '-o', 'ServerAliveInterval=18', '-o', 'ServerAliveCountMax=10']
 
     if url is not None and url.hostname is not None:
         url_string = url.hostname


### PR DESCRIPTION
After using btrfs-sxbackup for years, i finally had one that got too slow to complete its backup within the default keepalive timeout even after multiple retries.

Its an HDD based system with a lot of files in it. Having a lot of files can make BTRFS slow when sending snapshots (or when a btrfs balance job is running in parallel).

I suggest raising the timeout from 15 Seconds to 3 Minutes, as i do not see much drawback in having a higher timeout for an backup job.