### PR TITLE
Add --container-subvolume-relpath flag for init

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,11 @@ init
                             argument)
       -c, --compress        enables compression during transmission. Requires lzop
                             to be installed on both source and destination
+      -csr container-subvolume-relpath, --container-subvolume-relpath container-subvolume-relpath
+                            Name of the non-visible subvolume relative path on 
+                            the source side where metadata and backups are stored.
+                            This can only be set with init. Setting this is only
+                            required when the same source subvolume is being backed up to more than one location.
 
 run
 ---

--- a/btrfs_sxbackup/cli.py
+++ b/btrfs_sxbackup/cli.py
@@ -16,6 +16,7 @@ from subprocess import CalledProcessError
 from btrfs_sxbackup.core import Location
 from btrfs_sxbackup.core import Job
 from btrfs_sxbackup.core import Configuration
+from btrfs_sxbackup.core import DEFAULT_CONTAINER_RELPATH
 from btrfs_sxbackup.retention import RetentionExpression
 from btrfs_sxbackup import mail
 from btrfs_sxbackup import __version__
@@ -74,6 +75,15 @@ subvolumes_kwargs = {'type': str,
                      'metavar': 'subvolume',
                      'help': 'backup job source or destination subvolume. local path or SSH url'}
 
+container_subvolume_args = ['-csr', '--container-subvolume-relpath']
+container_subvolume_kwargs = {'type': str,
+                              'metavar': 'container-subvolume-relpath',
+                              'default': DEFAULT_CONTAINER_RELPATH,
+                              'help': 'Name of the non-visible subvolume relative path on the source'
+                                      ' side where metadata and backups are stored.  This can only be'
+                                      ' set with init.  Setting this is only required when the same'
+                                      ' source subvolume is being backed up to more than one location.'}
+
 # Initialize command cmdline params
 p_init = subparsers.add_parser(_CMD_INIT, help='initialize backup job')
 p_init.add_argument('source_subvolume', type=str, metavar='source-subvolume',
@@ -83,6 +93,7 @@ p_init.add_argument('destination_subvolume', type=str, metavar='destination-subv
 p_init.add_argument(*source_retention_args, **source_retention_kwargs)
 p_init.add_argument(*destination_retention_args, **destination_retention_kwargs)
 p_init.add_argument(*compress_args, **compress_kwargs)
+p_init.add_argument(*container_subvolume_args, **container_subvolume_kwargs)
 
 p_destroy = subparsers.add_parser(_CMD_DESTROY, help='destroy backup job by removing configuration files from source'
                                                      ' and destination. backup snapshots will be kept on both sides'
@@ -227,6 +238,7 @@ def main():
                            dest_url=urllib.parse.urlsplit(args.destination_subvolume) if args.destination_subvolume
                            else None,
                            dest_retention=destination_retention,
+			   container_subvolume_relpath=args.container_subvolume_relpath,
                            compress=args.compress)
 
         elif args.command == _CMD_UPDATE:

--- a/btrfs_sxbackup/core.py
+++ b/btrfs_sxbackup/core.py
@@ -28,7 +28,7 @@ from btrfs_sxbackup.entities import Subvolume
 _logger = logging.getLogger(__name__)
 _DEFAULT_RETENTION_SOURCE = RetentionExpression('3')
 _DEFAULT_RETENTION_DESTINATION = RetentionExpression('2d: 1/d, 2w:3/w, 1m:1/w, 2m:none')
-_DEFAULT_CONTAINER_RELPATH = '.sxbackup'
+DEFAULT_CONTAINER_RELPATH = '.sxbackup'
 
 
 class Error(Exception):
@@ -380,7 +380,7 @@ class JobLocation(Location):
         self.location_type = location_type
 
         if self.location_type == JobLocation.TYPE_SOURCE and container_subvolume_relpath is None:
-            self.container_subvolume_relpath = _DEFAULT_CONTAINER_RELPATH
+            self.container_subvolume_relpath = DEFAULT_CONTAINER_RELPATH
         else:
             self.container_subvolume_relpath = container_subvolume_relpath
 
@@ -791,6 +791,7 @@ class Job:
              source_retention: RetentionExpression = None,
              dest_retention: RetentionExpression = None,
              compress: bool = None,
+	     container_subvolume_relpath: str = DEFAULT_CONTAINER_RELPATH,
              identical_filesystem: bool = False) -> 'Job':
         """
         Initializes a new backup job
@@ -802,7 +803,7 @@ class Job:
         :return: Backup job
         :rtype: Job
         """
-        source = JobLocation(source_url, location_type=JobLocation.TYPE_SOURCE)
+        source = JobLocation(source_url, location_type=JobLocation.TYPE_SOURCE, container_subvolume_relpath=container_subvolume_relpath)
         dest = JobLocation(dest_url, location_type=JobLocation.TYPE_DESTINATION) if dest_url else None
 
         if source.has_configuration():
@@ -893,7 +894,7 @@ class Job:
         corresponding_location = None
         try:
             if not location.has_configuration():
-                location.container_subvolume_relpath = _DEFAULT_CONTAINER_RELPATH
+                location.container_subvolume_relpath = DEFAULT_CONTAINER_RELPATH
 
             corresponding_location = location.read_configuration()
         except subprocess.CalledProcessError:


### PR DESCRIPTION
This is to allow the same source to be backed up to multiple destinations