### PR TITLE
Remove requirement for sphinx in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@
 import sys
 import glob
 import os
-import sphinx
 import shutil
 from setuptools import setup
 from setuptools.command.sdist import sdist
@@ -23,6 +22,8 @@ DOC_MAN_PATH = './docs/man'
 class CustomSdist(sdist):
     """ Custom setuptools sdist command class """
     def run(self):
+        import sphinx
+
         input_dir = './docs/sphinx'
         build_doctree_dir = './build/doctrees'
         build_output_dir = './build/man'
@@ -68,6 +69,7 @@ setup(
     description='Incremental btrfs snapshot backups with push/pull support via SSH',
     long_description=open('README.rst').read(),
     data_files=[("man/man1/", glob.glob(os.path.join(DOC_MAN_PATH, '*.1')))],
+    install_requires=['sphinx'],
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: End Users/Desktop',


### PR DESCRIPTION
This allows `pip install` to be successfully run when the `sphinx` package is not installed on the system. In this case pip will see it as an unmet dependency and install it automatically.