### PR TITLE
Allow specifying non-default config file location

### DIFF
--- a/btrfs_sxbackup/cli.py
+++ b/btrfs_sxbackup/cli.py
@@ -40,6 +40,8 @@ parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', default=
 parser.add_argument('--version', action='version', version='%s v%s' % (_APP_NAME, __version__))
 parser.add_argument('-v', dest='verbosity', action='count',
                     help='can be specified multiple times to increase verbosity')
+parser.add_argument('-C', '--config', dest='configpath', type=str,
+                    help='specify path to non-default config file')
 
 subparsers = parser.add_subparsers()
 subparsers.required = True
@@ -134,8 +136,8 @@ def main():
     # Initialize logging
     args = parser.parse_args()
 
-    # Read global configuration
-    Configuration.instance().read()
+    # Read configuration
+    Configuration.instance(path=args.configpath).read()
 
     logger = logging.getLogger()
 

--- a/btrfs_sxbackup/core.py
+++ b/btrfs_sxbackup/core.py
@@ -48,20 +48,21 @@ class Configuration:
     __KEY_LOG_IDENT = 'log-ident'
     __key_EMAIL_RECIPIENT = 'email-recipient'
 
-    def __init__(self):
+    def __init__(self, path=None):
+        self.__path = path
         self.__source_retention = None
         self.__destination_retention = None
         self.__log_ident = None
         self.__email_recipient = None
 
     @staticmethod
-    def instance():
+    def instance(path=None):
         """
         :return: Singleton instance
         :rtype: Configuration
         """
         if not Configuration.__instance:
-            Configuration.__instance = Configuration()
+            Configuration.__instance = Configuration(path)
         return Configuration.__instance
 
     @property
@@ -83,8 +84,11 @@ class Configuration:
     def read(self):
         cparser = ConfigParser()
 
-        if os.path.exists(self.__CONFIG_FILENAME):
-            with open(self.__CONFIG_FILENAME, 'r') as file:
+        if self.__path is None and os.path.exists(self.__CONFIG_FILENAME):
+            self.__path = self.__CONFIG_FILENAME
+
+        if os.path.exists(self.__path):
+            with open(self.__path, 'r') as file:
                 cparser.read_file(file)
 
             source_retention_str = cparser.get(self.__SECTION_NAME, self.__KEY_SOURCE_RETENTION, fallback=None)


### PR DESCRIPTION
Add global option to specify a path to the global config file. I don't want to have my config file in the default location of `/etc/btrfs-sxbackup.conf`. This allows potentially various different configs to be used simultaneously.