### PR TITLE
Add support for ssh arguments in config file

### DIFF
--- a/btrfs_sxbackup/entities.py
+++ b/btrfs_sxbackup/entities.py
@@ -164,9 +164,10 @@ class Filesystem:
     
     __regex = re.compile('uuid: .*\\n')
     
-    def __init__(self, path, url=None):
+    def __init__(self, path, url=None, ssh_options=None):
         self.__path = os.path.abspath(path)
         self.url = url
+        self.ssh_options = ssh_options
     
     @property
     def path(self):
@@ -177,7 +178,7 @@ class Filesystem:
         currentpath = self.__path
         for x in range(0, len(currentpath.split(os.path.sep))):
             try:
-                ret = shell.exec_check_output('btrfs fi show %s' % currentpath, self.url)
+                ret = shell.exec_check_output('btrfs fi show %s' % currentpath, self.url, self.ssh_options)
             except Exception as e:
                 pass
             else:

--- a/btrfs_sxbackup/shell.py
+++ b/btrfs_sxbackup/shell.py
@@ -7,17 +7,19 @@
 
 import subprocess
 import logging
+import shlex
 
 
 _logger = logging.getLogger(__name__)
 
 
-def build_subprocess_args(cmd, url=None):
+def build_subprocess_args(cmd, url=None, ssh_options=None):
     """
     Create subprocess arguments for shell command/args to be executed
     Internally Wraps command into ssh call if url host name is not None
     :param cmd: Shell command string or argument list
     :param url: url of remote host
+    :param ssh_options: list of options for ssh
     :return: Subprocess arguments
     """
     # in case cmd is a regular value, convert to list
@@ -25,7 +27,10 @@ def build_subprocess_args(cmd, url=None):
     # wrap into bash or ssh command respectively
     # depending if command is executed locally (host==None) or remotely
     url_string = None
-    ssh_args = ['ssh', '-o', 'ServerAliveInterval=5', '-o', 'ServerAliveCountMax=3']
+    if ssh_options:
+        ssh_options = shlex.split(ssh_options)
+    ssh_options = ssh_options or ['-o', 'ServerAliveInterval=5', '-o', 'ServerAliveCountMax=3']
+    ssh_args = ['ssh'] + ssh_options
 
     if url is not None and url.hostname is not None:
         url_string = url.hostname
@@ -44,34 +49,37 @@ def build_subprocess_args(cmd, url=None):
     return subprocess_args
 
 
-def exec_check_output(cmd, url=None) -> bytes:
+def exec_check_output(cmd, url=None, ssh_options=None) -> bytes:
     """
     Wrapper for subprocess.check_output
     :param cmd: Command text
     :param url: URL
+    :param ssh_options: list of options for ssh
     :return: output
     """
-    return subprocess.check_output(build_subprocess_args(cmd, url), stderr=subprocess.STDOUT)
+    return subprocess.check_output(build_subprocess_args(cmd, url, ssh_options), stderr=subprocess.STDOUT)
 
 
-def exec_call(cmd, url=None) -> int:
+def exec_call(cmd, url=None, ssh_options=None) -> int:
     """
     Wrapper for subprocess.call
     :param cmd: Command text
     :param url: URL
+    :param ssh_options: list of options for ssh
     :return:
     """
-    return subprocess.call(build_subprocess_args(cmd, url), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    return subprocess.call(build_subprocess_args(cmd, url, ssh_options), stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
 
-def exists(command, url=None):
+def exists(command, url=None, ssh_options=None):
     """
     Check if shell command exists
     :param command: Command to verify
     :param url: url of remote host
+    :param ssh_options: list of options for ssh
     :return: True if location exists, otherwise False
     """
-    type_prc = subprocess.Popen(build_subprocess_args(['type ' + command], url),
+    type_prc = subprocess.Popen(build_subprocess_args(['type ' + command], url, ssh_options),
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 shell=False)

--- a/etc/btrfs-sxbackup.conf
+++ b/etc/btrfs-sxbackup.conf
@@ -3,3 +3,4 @@ destination-retention = 10
 source-retention = 10
 email-recipient = 
 log-ident =
+ssh-options = -o ServerAliveInterval=5 -o ServerAliveCountMax=3


### PR DESCRIPTION
This PR allows giving arbitrary options to ssh by specifying them in the `ssh-options` config file option. If this option is not specified the default options `-o ServerAliveInterval=5 -o ServerAliveCountMax=3` will be used (as is currently the case). Primarily I wanted this to allow specifying an alternate ssh config file and identity files.