### PR TITLE
Describe passing the destination url for working transfer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,8 +162,10 @@ run
                               subvolume [subvolume ...]
 
     positional arguments:
-      subvolume             backup job source or destination subvolume. local path
-                            or SSH url
+      subvolume             backup job source or destination subvolume. Local path
+                            or SSH url. To transfer backup from remote machine to 
+                            local you need to pass the 'destination' path instead 
+                            of remote SSH url.
 
     optional arguments:
       -h, --help            show this help message and exit


### PR DESCRIPTION
Added description that you need to pass the destination url to run job, if source is on remote machine accessed via SSH, to make transfer to destination job done. Fixes #72